### PR TITLE
String escaping on File.write/read

### DIFF
--- a/system/file.ts
+++ b/system/file.ts
@@ -9,8 +9,34 @@ export class File {
   private constructor() { }
 
   /**
+   * Character we use for escape sequences. Avoiding `\` since it is
+   * automatically escaped by `Preload`.
+  */
+  private static escapeCharacter = String.fromCharCode(27);
+  private static escapedSelf = File.escapeCharacter + File.escapeCharacter;
+  private static escapedQuote = File.escapeCharacter + "q";
+
+  /**
+   * Escapes the double quote character, which would otherwise bork file
+   * reading.
+   */
+  private static escape(contents: string) {
+    contents = string.gsub(contents, File.escapeCharacter, File.escapedSelf)[0];
+    contents = string.gsub(contents, '"', File.escapedQuote)[0];
+    return contents;
+  }
+
+  /**
+   * Undos File.escape, returning a string back to its original form.
+   */
+  private static unescape(contents: string) {
+    contents = string.gsub(contents, File.escapedQuote, '"')[0];
+    contents = string.gsub(contents, File.escapedSelf, File.escapeCharacter)[0];
+    return contents;
+  }
+
+  /**
   * Read text from a file.
-  * @param filename Filename of the file.
   */
   public static read(filename: string): string | undefined {
     const originalIcon = BlzGetAbilityIcon(this.dummyAbility);
@@ -18,14 +44,12 @@ export class File {
     const preloadText = BlzGetAbilityIcon(this.dummyAbility);
     BlzSetAbilityIcon(this.dummyAbility, originalIcon);
     if (preloadText !== originalIcon) {
-      return preloadText;
+      return File.unescape(preloadText);
     }
   }
 
   /**
    * Write text to a file with the option to not include boilerplate for reading the file back.
-   * @param filename Filename of the file.
-   * @param contents Contents to write to the file.
    */
   public static writeRaw(filename: string, contents: string, allowReading = false): File {
     PreloadGenClear();
@@ -33,6 +57,7 @@ export class File {
 
     if (allowReading) {
       Preload(`\")\n//! beginusercode\nlocal o=''\nPreload=function(s)o=o..s end\nPreloadEnd=function()end\n//!endusercode\n//`);
+      contents = File.escape(contents);
     }
 
     for (let i = 0; i < (contents.length / File.preloadLimit); i++) {
@@ -50,8 +75,6 @@ export class File {
 
   /**
    * Write text to a file.
-   * @param filename Filename of the file.
-   * @param contents Contents to write to the file.
    */
   public static write(filename: string, contents: string): File {
     return this.writeRaw(filename, contents, true);


### PR DESCRIPTION
Adds escaping for quotes (`"`), using the [ASCII escape character](https://en.wikipedia.org/wiki/Escape_character#ASCII_escape_character) (`"` → `␛q`).