### PR TITLE
Add new function to class Force which retrieves all Player handles

### DIFF
--- a/handles/force.ts
+++ b/handles/force.ts
@@ -25,6 +25,17 @@ export class Force extends Handle<force> {
     DestroyForce(this.handle);
   }
 
+  /**
+   * Returns all player handles belonging to this force
+   */
+  public getPlayers(){
+    let players: player[] = []
+
+    ForForce(this.handle, () => players.push(GetEnumPlayer()));
+
+    return players
+  }
+
   public enumAllies(whichPlayer: MapPlayer, filter: boolexpr | (() => boolean)) {
     ForceEnumAllies(this.handle, whichPlayer.handle, filter);
   }


### PR DESCRIPTION
Given the use case that you want to retrieve all the `Players` belonging to a `Force`, you would need to do something like this:
```ts
const force = Force.fromHandle(GetPlayersAll())
let players: player[] = []
force.for(() => player.push(GetEnumPlayer())
```

where now you can write it like this:

```ts
const force = Force.fromHandle(GetPlayersAll())
const players = force.getPlayers()
```

Testable implementation: https://github.com/jejanim/rc/blob/test-force-cb/src/main.ts#L16
