### PR TITLE
Add Angle and Vector types 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export * from "./handles/index";
 export * from "./hooks/index";
 export * from "./system/index";
+export * from "./math/index";
 export { tsGlobals };
 import * as tsGlobals from "./globals/index";

--- a/math/index.ts
+++ b/math/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/math/types.ts
+++ b/math/types.ts
@@ -1,8 +1,8 @@
 import { Point } from "../handles/point";
 
-/** Converts Degrees to Radians */
+// Converts Degrees to Radians
 const DEGTORAD = 0.017453293;
-/** Converts Radians to Degrees */
+// Converts Radians to Degrees
 const RADTODEG = 57.295779513;
 
 /**
@@ -11,41 +11,41 @@ const RADTODEG = 57.295779513;
 export class Angle {
   protected constructor(private readonly rads: number) {}
 
-  static fromDegrees(degrees: number) {
+  public static fromDegrees(degrees: number) {
     return new Angle(degrees * DEGTORAD);
   }
 
-  static fromRadians(radians: number) {
+  public static fromRadians(radians: number) {
     return new Angle(radians);
   }
 
-  static random() {
+  public static random() {
     return new Angle(GetRandomReal(0, math.pi * 2));
   }
 
-  get degrees() {
+  public get degrees() {
     return this.rads * RADTODEG;
   }
 
-  get radians() {
+  public get radians() {
     return this.rads;
   }
 
-  get cos() {
+  public get cos() {
     return Cos(this.rads);
   }
 
-  get sin() {
+  public get sin() {
     return Sin(this.rads);
   }
 
-  add(other: Angle) {
+  public add(other: Angle) {
     return new Angle(this.radians + other.radians);
   }
 
   // returns a unit length Vec2 in the direction of this angle,
   // parallel to the ground plane.
-  asDirection() {
+  public asDirection() {
     return new Vec2(this.cos, this.sin);
   }
 }
@@ -55,7 +55,7 @@ export const radians = Angle.fromRadians;
 export const randomAngle = Angle.random;
 
 export class Vec2 {
-  constructor(readonly x: number, readonly y: number) {}
+  public constructor(readonly x: number, readonly y: number) {}
 
   public withZ(z: number) {
     return new Vec3(this.x, this.y, z);
@@ -162,33 +162,37 @@ export class Vec2 {
 }
 
 export class Vec3 {
-  constructor(readonly x: number, readonly y: number, readonly z: number) {}
+  public constructor(
+    readonly x: number,
+    readonly y: number,
+    readonly z: number
+  ) {}
 
-  toVec2() {
+  public toVec2() {
     return new Vec2(this.x, this.y);
   }
 
-  add(other: Vec3): Vec3 {
+  public add(other: Vec3): Vec3 {
     return new Vec3(this.x + other.x, this.y + other.y, this.z + other.z);
   }
 
-  sub(other: Vec3): Vec3 {
+  public sub(other: Vec3): Vec3 {
     return new Vec3(this.x - other.x, this.y - other.y, this.z - other.z);
   }
 
-  scale(factor: number): Vec3 {
+  public scale(factor: number): Vec3 {
     return new Vec3(this.x * factor, this.y * factor, this.z * factor);
   }
 
-  mul(other: Vec3): Vec3 {
+  public mul(other: Vec3): Vec3 {
     return new Vec3(this.x * other.x, this.y * other.y, this.z * other.z);
   }
 
-  dot(other: Vec3): number {
+  public dot(other: Vec3): number {
     return this.x * other.x + this.y * other.y + this.z * other.z;
   }
 
-  cross(other: Vec3) {
+  public cross(other: Vec3) {
     return new Vec3(
       this.y * other.z - this.z * other.y,
       this.z * other.x - this.x * other.z,
@@ -196,15 +200,15 @@ export class Vec3 {
     );
   }
 
-  get length(): number {
+  public get length(): number {
     return SquareRoot(this.lengthSq);
   }
 
-  get lengthSq(): number {
+  public get lengthSq(): number {
     return this.x * this.x + this.y * this.y + this.z * this.z;
   }
 
-  get norm(): Vec3 {
+  public get norm(): Vec3 {
     const len = this.length;
     if (len > 0) {
       return new Vec3(this.x / len, this.y / len, this.z / len);
@@ -215,7 +219,7 @@ export class Vec3 {
   // returns a normalized vector in the direction of the
   // target. When the target and origin vector are equal, returns the x-axis
   // unit vector.
-  normalizedPointerTo(other: Vec3) {
+  public normalizedPointerTo(other: Vec3) {
     const v = other.sub(this).norm;
     if (v.length == 0) {
       return new Vec3(1, 0, 0);
@@ -223,11 +227,11 @@ export class Vec3 {
     return v;
   }
 
-  distanceTo(other: Vec3) {
+  public distanceTo(other: Vec3) {
     return other.sub(this).length;
   }
 
-  distanceToSq(other: Vec3) {
+  public distanceToSq(other: Vec3) {
     return other.sub(this).lengthSq;
   }
 

--- a/math/types.ts
+++ b/math/types.ts
@@ -1,0 +1,44 @@
+/** Converts Degrees to Radians */
+const DEGTORAD = 0.017453293;
+/** Converts Radians to Degrees */
+const RADTODEG = 57.295779513;
+
+export class Angle {
+  protected constructor(private readonly rads: number) {}
+
+  static fromDegrees(degrees: number) {
+    return new Angle(degrees * DEGTORAD);
+  }
+
+  static fromRadians(radians: number) {
+    return new Angle(radians);
+  }
+
+  static random() {
+    return new Angle(GetRandomReal(0, math.pi * 2));
+  }
+
+  get degrees() {
+    return this.rads * RADTODEG;
+  }
+
+  get radians() {
+    return this.rads;
+  }
+
+  get cos() {
+    return Cos(this.rads);
+  }
+
+  get sin() {
+    return Sin(this.rads);
+  }
+
+  add(other: Angle) {
+    return new Angle(this.radians + other.radians);
+  }
+}
+
+export const degress = Angle.fromDegrees;
+export const radians = Angle.fromRadians;
+export const randomAngle = Angle.random;

--- a/math/types.ts
+++ b/math/types.ts
@@ -149,11 +149,10 @@ export class Vec2 {
     return this.distanceToSq(other) < radius * radius;
   }
 
+  private static terrainPoint: Point = new Point(0, 0);
   public get terrainZ() {
-    const temp = new Point(this.x, this.y);
-    const z = temp.z;
-    temp.destroy();
-    return z;
+    Vec2.terrainPoint.setPosition(this.x, this.y);
+    return Vec2.terrainPoint.z;
   }
 
   public toString() {

--- a/math/types.ts
+++ b/math/types.ts
@@ -1,8 +1,13 @@
+import { Point } from "../handles/point";
+
 /** Converts Degrees to Radians */
 const DEGTORAD = 0.017453293;
 /** Converts Radians to Degrees */
 const RADTODEG = 57.295779513;
 
+/**
+ * Angle encapsulates an angle, abstracting the usage of degrees and radians.
+ * */
 export class Angle {
   protected constructor(private readonly rads: number) {}
 
@@ -37,8 +42,115 @@ export class Angle {
   add(other: Angle) {
     return new Angle(this.radians + other.radians);
   }
+
+  // asDirection returns a unit length Vec2 in the direction of this angle,
+  // parallel to the ground plane.
+  asDirection() {
+    return new Vec2(this.cos, this.sin);
+  }
 }
 
-export const degress = Angle.fromDegrees;
+export const degrees = Angle.fromDegrees;
 export const radians = Angle.fromRadians;
 export const randomAngle = Angle.random;
+
+export class Vec2 {
+  constructor(readonly x: number, readonly y: number) {}
+
+  public get terrainZ() {
+    const temp = new Point(this.x, this.y);
+    const z = temp.z;
+    temp.destroy();
+    return z;
+  }
+
+  public add(other: Vec2) {
+    return new Vec2(this.x + other.x, this.y + other.y);
+  }
+
+  public sub(other: Vec2) {
+    return new Vec2(this.x - other.x, this.y - other.y);
+  }
+
+  public scale(factor: number) {
+    return new Vec2(this.x * factor, this.y * factor);
+  }
+
+  public mul(other: Vec2) {
+    return new Vec2(this.x * other.x, this.y * other.y);
+  }
+
+  public dot(other: Vec2) {
+    return this.x * other.x + this.y * other.y;
+  }
+
+  public get length() {
+    return SquareRoot(this.lengthSq);
+  }
+
+  public get lengthSq() {
+    return this.x * this.x + this.y * this.y;
+  }
+
+  public get norm() {
+    const len = this.length;
+    if (len > 0) {
+      return new Vec2(this.x / len, this.y / len);
+    }
+    return new Vec2(this.x, this.y);
+  }
+
+  // rotate rotates this vector around the Z axis (up from the ground).
+  public rotate(angle: Angle): Vec2 {
+    const cos = angle.cos;
+    const sin = angle.sin;
+
+    const px = this.x * cos - this.y * sin;
+    const py = this.x * sin + this.y * cos;
+    return new Vec2(px, py);
+  }
+
+  public angleTo(other: Vec2): Angle {
+    // Weird implementation note: this method causes map start failures when
+    // not in the same file in as the Angle class.
+    const dir = this.normalizedPointerTo(other);
+    return Angle.fromRadians(Atan2(dir.y, dir.x));
+  }
+
+  // normalizedPointerTo returns a normalized vector in the direction of the
+  // target. When the target and this vector are equal, return a vector
+  // pointing right.
+  public normalizedPointerTo(other: Vec2): Vec2 {
+    let v = other.sub(this).norm;
+    if (v.length == 0) {
+      return new Vec2(1, 0);
+    }
+    return v;
+  }
+
+  public moveTowards(other: Vec2, dist: number) {
+    return this.add(this.normalizedPointerTo(other).scale(dist));
+  }
+
+  public polarOffset(angle: Angle, dist: number) {
+    return this.add(angle.asDirection().scale(dist));
+  }
+
+  public distanceTo(other: Vec2) {
+    return other.sub(this).length;
+  }
+
+  public distanceToSq(other: Vec2) {
+    return other.sub(this).lengthSq;
+  }
+
+  public inRange(other: Vec2, radius: number): boolean {
+    return this.distanceToSq(other) < radius * radius;
+  }
+
+  public toString() {
+    return "(" + this.x.toString() + ", " + this.y.toString() + ")";
+  }
+}
+
+export const vec2 = (x: number, y: number) => new Vec2(x, y);


### PR DESCRIPTION
Add a math folder with types file to contain useful types for basic spatial mathematics. 

The Angle type can be used to abstract the problem of degrees versus radians in the Warcraft III API, since it inconsistently uses angular units. Changing the type of `Unit.setFacing(value: number)` to `Unit.setFacing(value: Angle)` would allow the library to know that the `SetUnitFacing()` takes an angle in degrees.

The Vectors are useful as they can store a location, but not require explicit cleanup. Instead the Lua memory management will cleanup vectors, lowering the usage burden. They also have useful functionality and can have more WC3 specific functionality added.

I'd like to follow this PR up with another that replaces all usages of the `Point` class, plain x&y number arguments, and raw number angles with these strongly typed alternatives, but this would be a big breaking change. What are your thoughts @cipherxof ?

Having the well typed angles and vectors is something I've missed from Wurst, so I wanted to add them to this library 😄 