### PR TITLE
Fix an error in the binary reader

### DIFF
--- a/system/binaryreader.ts
+++ b/system/binaryreader.ts
@@ -38,7 +38,7 @@ export class BinaryReader {
   public read(fmt: string, size: number) {
     const unpacked = string.unpack(fmt, this.data, this.pos);
     this.pos += size;
-    if (unpacked.length <= 0) {
+    if (typeof unpacked === 'number' || unpacked.length <= 0) {
       return 0;
     }
     return unpacked[0];


### PR DESCRIPTION
if the return of string.unpack is just a number it flips its shit